### PR TITLE
[BUGFIX] Fix colPos for newly added content elements.

### DIFF
--- a/Classes/DataHandler/PreProcessFieldArray.php
+++ b/Classes/DataHandler/PreProcessFieldArray.php
@@ -68,14 +68,19 @@ class PreProcessFieldArray extends AbstractDataHandler {
 	 * @return void
 	 */
 	public function processFieldArrayForTtContent(array &$fieldArray) {
+		$pid = 0;
+
 		if ($this->getTable() === 'tt_content') {
 			$pid = (int)GeneralUtility::_GET('DDinsertNew');
 
 			if (abs($pid) > 0) {
 				$this->setDefaultFieldValues($fieldArray, $pid);
 				$this->getDefaultFlexformValues($fieldArray);
+			} else {
+				$this->copyDefaults($fieldArray);
 			}
 		}
+
 		$this->setFieldEntries($fieldArray, $pid);
 	}
 
@@ -123,19 +128,7 @@ class PreProcessFieldArray extends AbstractDataHandler {
 			}
 		}
 
-		// Default values as submitted:
-		$this->defVals = GeneralUtility::_GP('defVals');
-		$this->overrideVals = GeneralUtility::_GP('overrideVals');
-		if (!is_array($this->defVals) && is_array($this->overrideVals)) {
-			$this->defVals = $this->overrideVals;
-		}
-		if (is_array($this->defVals['tt_content'])) {
-			foreach ($this->defVals['tt_content'] as $theF => $theV) {
-				if (isset($GLOBALS['TCA']['tt_content']['columns'][$theF])) {
-					$newRow[$theF] = $theV;
-				}
-			}
-		}
+		$this->copyDefaults($newRow);
 
 		// Fetch default values if a previous record exists
 		if ($pid < 0 && $GLOBALS['TCA']['tt_content']['ctrl']['useColumnsForDefaultValues']) {
@@ -156,6 +149,24 @@ class PreProcessFieldArray extends AbstractDataHandler {
 			}
 		}
 		$fieldArray = array_merge($newRow, $fieldArray);
+	}
+
+	protected function copyDefaults(array &$row) {
+		// Default values as submitted:
+		$defaults = GeneralUtility::_GP('defVals');
+		$overrides = GeneralUtility::_GP('overrideVals');
+
+		if (!is_array($defaults) && is_array($overrides)) {
+			$defaults = $overrides;
+		}
+
+		if (isset($defaults['tt_content']) && is_array($defaults['tt_content'])) {
+			foreach ($defaults['tt_content'] as $column => $value) {
+				if (isset($GLOBALS['TCA']['tt_content']['columns'][$column])) {
+					$row[$column] = $value;
+				}
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
In the TYPO3 CMS backend, newly added content elements
were not displayed in the container they have been added to.
This was caused due to the colPos being set to 0 instead of
-1.
